### PR TITLE
Add filename Option to allow relative includes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 const pug = require('pug');
 
-function transformPugToHtml(src) {
+function transformPugToHtml(src, filename) {
   try {
-    const template = pug.compile(src);
+    const template = pug.compile(src, { filename });
     const html = template();
     const content = JSON.stringify(html);
     return `module.exports = ${content};`;


### PR DESCRIPTION
In order to allow relative includes, we are adding the filename options
that allows pug to resolve the relative path.